### PR TITLE
Add drag-and-drop functionality for items

### DIFF
--- a/API_COORDINATION.md
+++ b/API_COORDINATION.md
@@ -1,0 +1,168 @@
+# API Coordination for Drag & Drop Functionality
+
+This document outlines the API endpoints that need to be implemented on the Python backend to support the drag and drop functionality for reordering experiences and skills.
+
+## Overview
+
+The frontend now includes drag and drop functionality that allows users to reorder items within sections (Experiences and Skills). When items are reordered, the frontend sends requests to update the order on the server.
+
+## Required API Endpoints
+
+### 1. Fetch Experiences
+- **Endpoint**: `GET /resume/experience`
+- **Purpose**: Retrieve all experiences for display
+- **Expected Response Format**:
+```json
+[
+  {
+    "id": 1,
+    "title": "Software Engineer",
+    "company": "Tech Corp",
+    "start_date": "2022-01-01",
+    "end_date": "2023-12-31",
+    "description": "Developed web applications using React and Python",
+    "logo": "https://example.com/logo.png",
+    "order": 0
+  },
+  {
+    "id": 2,
+    "title": "Junior Developer",
+    "company": "StartupCo",
+    "start_date": "2021-06-01",
+    "end_date": "2021-12-31",
+    "description": "Built frontend components and APIs",
+    "logo": "https://example.com/logo2.png",
+    "order": 1
+  }
+]
+```
+
+### 2. Fetch Skills
+- **Endpoint**: `GET /resume/skill`
+- **Purpose**: Retrieve all skills for display
+- **Expected Response Format**:
+```json
+[
+  {
+    "id": 1,
+    "name": "React",
+    "proficiency": "Advanced",
+    "logo": "https://example.com/react-logo.png",
+    "order": 0
+  },
+  {
+    "id": 2,
+    "name": "Python",
+    "proficiency": "Intermediate",
+    "logo": "https://example.com/python-logo.png",
+    "order": 1
+  }
+]
+```
+
+### 3. Update Experience Order
+- **Endpoint**: `PUT /resume/experience/reorder`
+- **Purpose**: Update the order of experiences when user drags and drops
+- **Request Format**:
+```json
+{
+  "experiences": [
+    {
+      "id": 2,
+      "order": 0
+    },
+    {
+      "id": 1,
+      "order": 1
+    }
+  ]
+}
+```
+- **Expected Response**: Success status (200 OK)
+
+### 4. Update Skill Order
+- **Endpoint**: `PUT /resume/skill/reorder`
+- **Purpose**: Update the order of skills when user drags and drops
+- **Request Format**:
+```json
+{
+  "skills": [
+    {
+      "id": 3,
+      "order": 0
+    },
+    {
+      "id": 1,
+      "order": 1
+    },
+    {
+      "id": 2,
+      "order": 2
+    }
+  ]
+}
+```
+- **Expected Response**: Success status (200 OK)
+
+### 5. Delete Experience
+- **Endpoint**: `DELETE /resume/experience/{id}`
+- **Purpose**: Delete a specific experience
+- **Expected Response**: Success status (200 OK or 204 No Content)
+
+### 6. Delete Skill
+- **Endpoint**: `DELETE /resume/skill/{id}`
+- **Purpose**: Delete a specific skill
+- **Expected Response**: Success status (200 OK or 204 No Content)
+
+## Database Schema Requirements
+
+### Experiences Table
+The experiences table should include an `order` field to store the display order:
+- `id` (Primary Key)
+- `title` (String)
+- `company` (String)
+- `start_date` (Date/String)
+- `end_date` (Date/String, nullable)
+- `description` (Text, nullable)
+- `logo` (String, nullable)
+- `order` (Integer) - **New field for ordering**
+
+### Skills Table
+The skills table should include an `order` field to store the display order:
+- `id` (Primary Key)
+- `name` (String)
+- `proficiency` (String, nullable)
+- `logo` (String, nullable)
+- `order` (Integer) - **New field for ordering**
+
+## Implementation Notes
+
+1. **Default Ordering**: When fetching experiences or skills, they should be ordered by the `order` field in ascending order.
+
+2. **New Item Order**: When a new experience or skill is added, it should be assigned the next available order number (max current order + 1).
+
+3. **Reordering Logic**: When updating order, the backend should update all affected items' order values based on the provided array.
+
+4. **Error Handling**: The API should return appropriate error responses (400, 404, 500) with descriptive error messages.
+
+5. **Data Validation**: Validate that all required fields are present and have valid values.
+
+## Frontend Integration
+
+The frontend components are already implemented and will:
+- Automatically fetch data on component mount
+- Send reorder requests when items are dragged and dropped
+- Handle loading states and error conditions
+- Provide visual feedback during drag operations
+
+## Testing
+
+Make sure to test:
+- Fetching empty lists (should return empty arrays)
+- Reordering with different combinations
+- Error scenarios (invalid IDs, network errors)
+- Concurrent access scenarios
+
+## Related GitHub Issue
+
+This implementation relates to issue: MLH-Fellowship/orientation-project-python#11

--- a/DRAG_DROP_IMPLEMENTATION.md
+++ b/DRAG_DROP_IMPLEMENTATION.md
@@ -1,0 +1,119 @@
+# Drag & Drop Implementation Summary
+
+## What Was Implemented
+
+✅ **Drag and Drop Components**
+- `ExperiencesList.js` - Displays experiences as a draggable list
+- `ExperienceItem.js` - Individual draggable experience items
+- `SkillsList.js` - Displays skills as a draggable list  
+- `SkillItem.js` - Individual draggable skill items
+
+✅ **Styling**
+- `ExperiencesList.css` - Styling for experiences list
+- `ExperienceItem.css` - Styling for individual experience items
+- `SkillsList.css` - Styling for skills list
+- `SkillItem.css` - Styling for individual skill items
+
+✅ **Integration**
+- Updated `App.js` to use the new draggable components
+- Installed `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` for drag and drop functionality
+
+✅ **API Integration**
+- Fetch existing experiences and skills from the server
+- Send reorder requests when items are dragged and dropped
+- Delete functionality for individual items
+- Error handling and loading states
+
+## Features
+
+🎯 **Drag and Drop Reordering**
+- Users can drag experience and skill items up and down to reorder them
+- Visual feedback during dragging (rotation, shadow effects)
+- Smooth animations and transitions
+
+🎯 **Data Management**
+- Automatically fetches existing data on component load
+- Sends API requests to update order when items are reordered
+- Real-time updates without page refresh
+
+🎯 **User Experience**
+- Visual drag handles (⋮⋮) to indicate draggable areas
+- Loading states while fetching data
+- Error handling with retry options
+- Empty state messages when no items exist
+- Delete buttons for removing items
+
+🎯 **Responsive Design**
+- Works on desktop and mobile devices
+- Touch-friendly for mobile users
+
+## How to Use
+
+1. **Adding Items**: Use the existing "Add Experience" and "Add Skill" buttons to add new items
+2. **Reordering**: Click and drag the handle (⋮⋮) on the left side of any item to reorder it
+3. **Deleting**: Click the trash icon (🗑️) on any item to delete it
+
+## API Requirements
+
+The frontend expects the following API endpoints to be implemented on the Python backend:
+
+- `GET /resume/experience` - Fetch all experiences
+- `GET /resume/skill` - Fetch all skills
+- `PUT /resume/experience/reorder` - Update experience order
+- `PUT /resume/skill/reorder` - Update skill order
+- `DELETE /resume/experience/{id}` - Delete an experience
+- `DELETE /resume/skill/{id}` - Delete a skill
+
+See `API_COORDINATION.md` for detailed API specifications.
+
+## Testing the Implementation
+
+1. **Start the React development server**:
+   ```bash
+   npm start
+   ```
+
+2. **Test with Mock Data** (if backend isn't ready):
+   - The components will show appropriate empty states if the API endpoints return empty arrays
+   - Error states will be displayed if the API endpoints are not available
+
+3. **Full Testing** (when backend is ready):
+   - Add some experiences and skills using the existing forms
+   - Try dragging and dropping to reorder items
+   - Verify that the order persists after page refresh
+   - Test the delete functionality
+
+## Browser Support
+
+- Modern browsers with support for:
+  - ES6+ features
+  - CSS Grid and Flexbox
+  - Touch events (for mobile drag and drop)
+
+## Dependencies Added
+
+- `@dnd-kit/core` - Core drag and drop functionality
+- `@dnd-kit/sortable` - Sortable list functionality
+- `@dnd-kit/utilities` - Utility functions for drag and drop
+
+## Next Steps
+
+1. **Backend Implementation**: Work with the Python team to implement the API endpoints specified in `API_COORDINATION.md`
+2. **Testing**: Test the full workflow once the backend is ready
+3. **Optimization**: Consider adding animations or additional visual feedback
+4. **Accessibility**: Add keyboard navigation support for drag and drop (already partially supported through dnd-kit)
+
+## File Structure
+
+```
+src/
+├── ExperiencesList.js       # Main experiences list component
+├── ExperiencesList.css      # Styling for experiences list
+├── ExperienceItem.js        # Individual experience item
+├── ExperienceItem.css       # Styling for experience items
+├── SkillsList.js           # Main skills list component
+├── SkillsList.css          # Styling for skills list
+├── SkillItem.js            # Individual skill item
+├── SkillItem.css           # Styling for skill items
+└── App.js                  # Updated main app component
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@testing-library/jest-dom": "^6.6.3",
@@ -2385,6 +2386,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "orientation-project-js",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2355,6 +2358,59 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,5 @@
 import React, { useState } from "react";
 import "./App.css";
-import Form from "./Form";
-import SkillForm from "./SkillForm";
-import ExperienceForm from "./ExperienceForm";
 import { Link } from "react-router-dom";
 import AddExperience from "./AddExperience";
 import LogoDropzone from "./LogoDropzone";
@@ -10,30 +7,13 @@ import ExperiencesList from "./ExperiencesList";
 import SkillsList from "./SkillsList";
 
 function App({ userId, setUserId }) {
-  const [editMode, setEditMode] = useState(false);
-  const [skillEditMode, setSkillEditMode] = useState(false);
-  const [experienceEditMode, setExperienceEditMode] = useState(false);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
   const [linkedin, setLinkedin] = useState("");
   const [github, setGithub] = useState("");
   const [showExperienceForm, setShowExperienceForm] = useState(false);
-
-  function editEduHandler(e) {
-    e.preventDefault();
-    setEditMode(true);
-  }
-
-  function editSkillHandler(e) {
-    e.preventDefault();
-    setSkillEditMode(true);
-  }
-
-  function editExpHandler(e) {
-    e.preventDefault();
-    setExperienceEditMode(true);
-  }
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -109,9 +89,14 @@ function App({ userId, setUserId }) {
 
       <div className="resumeSection">
         <h2>Experience</h2>
-        <ExperiencesList />
+        <ExperiencesList key={`experiences-${refreshKey}`} />
         {showExperienceForm ? (
-          <AddExperience onCancel={() => setShowExperienceForm(false)} />
+          <AddExperience 
+            onCancel={() => {
+              setShowExperienceForm(false);
+              setRefreshKey(prev => prev + 1);
+            }} 
+          />
         ) : (
           <button onClick={() => setShowExperienceForm(true)}>
             Add Experience
@@ -127,7 +112,7 @@ function App({ userId, setUserId }) {
 
       <div className="resumeSection">
         <h2>Skills</h2>
-        <SkillsList />
+        <SkillsList key={`skills-${refreshKey}`} />
         <Link to="/addSkill">
           <button>Add skill</button>
         </Link>

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import ExperienceForm from "./ExperienceForm";
 import { Link } from "react-router-dom";
 import AddExperience from "./AddExperience";
 import LogoDropzone from "./LogoDropzone";
+import ExperiencesList from "./ExperiencesList";
+import SkillsList from "./SkillsList";
 
 function App({ userId, setUserId }) {
   const [editMode, setEditMode] = useState(false);
@@ -107,7 +109,7 @@ function App({ userId, setUserId }) {
 
       <div className="resumeSection">
         <h2>Experience</h2>
-        <p>Experience Placeholder</p>
+        <ExperiencesList />
         {showExperienceForm ? (
           <AddExperience onCancel={() => setShowExperienceForm(false)} />
         ) : (
@@ -125,7 +127,7 @@ function App({ userId, setUserId }) {
 
       <div className="resumeSection">
         <h2>Skills</h2>
-        <p>Skill Placeholder</p>
+        <SkillsList />
         <Link to="/addSkill">
           <button>Add skill</button>
         </Link>

--- a/src/ExperienceItem.css
+++ b/src/ExperienceItem.css
@@ -1,0 +1,153 @@
+.experience-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  margin: 10px 0;
+  background-color: #ffffff;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: default;
+}
+
+.experience-item:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.experience-item.dragging {
+  transform: rotate(5deg);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
+.experience-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 40px;
+  cursor: grab;
+  color: #6c757d;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.experience-drag-handle:hover {
+  background-color: #f8f9fa;
+  color: #495057;
+}
+
+.experience-drag-handle:active {
+  cursor: grabbing;
+}
+
+.drag-icon {
+  font-size: 18px;
+  line-height: 1;
+  user-select: none;
+}
+
+.experience-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.experience-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.experience-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  color: #212529;
+}
+
+.experience-company {
+  font-size: 16px;
+  color: #6c757d;
+  font-weight: 500;
+}
+
+.experience-dates {
+  font-size: 14px;
+  color: #868e96;
+  margin-bottom: 12px;
+  font-style: italic;
+}
+
+.experience-description {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #495057;
+  margin: 0 0 12px 0;
+}
+
+.experience-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid #e9ecef;
+}
+
+.experience-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background-color: #ffffff;
+}
+
+.experience-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.delete-button {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+  opacity: 0.6;
+}
+
+.delete-button:hover {
+  background-color: #f8f9fa;
+  opacity: 1;
+}
+
+.delete-button:active {
+  background-color: #e9ecef;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .experience-item {
+    padding: 12px;
+    gap: 8px;
+  }
+  
+  .experience-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+  
+  .experience-title {
+    font-size: 16px;
+  }
+  
+  .experience-company {
+    font-size: 14px;
+  }
+}

--- a/src/ExperienceItem.js
+++ b/src/ExperienceItem.js
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import "./ExperienceItem.css";
+
+const ExperienceItem = ({ experience, onDelete }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: experience.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const handleDelete = async () => {
+    if (window.confirm("Are you sure you want to delete this experience?")) {
+      try {
+        const response = await fetch(
+          `http://localhost:5000/resume/experience/${experience.id}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to delete experience");
+        }
+
+        onDelete(experience.id);
+      } catch (err) {
+        console.error("Error deleting experience:", err);
+        alert("Failed to delete experience. Please try again.");
+      }
+    }
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`experience-item ${isDragging ? "dragging" : ""}`}
+    >
+      <div className="experience-drag-handle" {...attributes} {...listeners}>
+        <span className="drag-icon">⋮⋮</span>
+      </div>
+      
+      <div className="experience-content">
+        <div className="experience-header">
+          <h3 className="experience-title">{experience.title}</h3>
+          <span className="experience-company">{experience.company}</span>
+        </div>
+        
+        <div className="experience-dates">
+          {experience.start_date} - {experience.end_date || "Present"}
+        </div>
+        
+        {experience.description && (
+          <p className="experience-description">{experience.description}</p>
+        )}
+        
+        {experience.logo && (
+          <div className="experience-logo">
+            <img src={experience.logo} alt={`${experience.company} logo`} />
+          </div>
+        )}
+      </div>
+      
+      <div className="experience-actions">
+        <button
+          className="delete-button"
+          onClick={handleDelete}
+          title="Delete experience"
+        >
+          🗑️
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ExperienceItem;

--- a/src/ExperiencesList.css
+++ b/src/ExperiencesList.css
@@ -1,0 +1,52 @@
+.experiences-list {
+  margin: 20px 0;
+  min-height: 50px;
+}
+
+.experiences-loading,
+.experiences-error,
+.experiences-empty {
+  padding: 20px;
+  text-align: center;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  color: #6c757d;
+  margin: 10px 0;
+}
+
+.experiences-error {
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+  color: #721c24;
+}
+
+.experiences-error button {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.experiences-error button:hover {
+  background-color: #c82333;
+}
+
+.experiences-empty {
+  background-color: #d1ecf1;
+  border-color: #bee5eb;
+  color: #0c5460;
+}
+
+/* Drag and drop feedback */
+.experiences-list .dnd-sortable-ghost {
+  opacity: 0.4;
+}
+
+.experiences-list .dnd-sortable-chosen {
+  cursor: grabbing;
+}

--- a/src/ExperiencesList.js
+++ b/src/ExperiencesList.js
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import {
+  restrictToVerticalAxis,
+  restrictToParentElement,
+} from "@dnd-kit/modifiers";
+import ExperienceItem from "./ExperienceItem";
+import "./ExperiencesList.css";
+
+const ExperiencesList = () => {
+  const [experiences, setExperiences] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // Fetch experiences from the server
+  useEffect(() => {
+    fetchExperiences();
+  }, []);
+
+  const fetchExperiences = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch("http://localhost:5000/resume/experience");
+      if (!response.ok) {
+        throw new Error("Failed to fetch experiences");
+      }
+      const data = await response.json();
+      setExperiences(data);
+    } catch (err) {
+      setError(err.message);
+      console.error("Error fetching experiences:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Update the order on the server
+  const updateExperienceOrder = async (newOrder) => {
+    try {
+      const response = await fetch(
+        "http://localhost:5000/resume/experience/reorder",
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            experiences: newOrder.map((exp, index) => ({
+              id: exp.id,
+              order: index,
+            })),
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update experience order");
+      }
+
+      console.log("Experience order updated successfully");
+    } catch (err) {
+      console.error("Error updating experience order:", err);
+      // Optionally show an error message to the user
+      setError("Failed to update order. Please try again.");
+    }
+  };
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id) {
+      setExperiences((items) => {
+        const oldIndex = items.findIndex((item) => item.id === active.id);
+        const newIndex = items.findIndex((item) => item.id === over.id);
+
+        const newOrder = arrayMove(items, oldIndex, newIndex);
+        
+        // Update the server with the new order
+        updateExperienceOrder(newOrder);
+        
+        return newOrder;
+      });
+    }
+  };
+
+  const handleDelete = (id) => {
+    setExperiences((prev) => prev.filter((exp) => exp.id !== id));
+  };
+
+  if (loading) {
+    return <div className="experiences-loading">Loading experiences...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="experiences-error">
+        <p>Error: {error}</p>
+        <button onClick={fetchExperiences}>Retry</button>
+      </div>
+    );
+  }
+
+  if (experiences.length === 0) {
+    return (
+      <div className="experiences-empty">
+        <p>No experiences added yet. Add your first experience above!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="experiences-list">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      >
+        <SortableContext
+          items={experiences.map((exp) => exp.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {experiences.map((experience) => (
+            <ExperienceItem
+              key={experience.id}
+              experience={experience}
+              onDelete={handleDelete}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+};
+
+export default ExperiencesList;

--- a/src/ExperiencesList.js
+++ b/src/ExperiencesList.js
@@ -88,7 +88,7 @@ const ExperiencesList = () => {
   const handleDragEnd = (event) => {
     const { active, over } = event;
 
-    if (active.id !== over?.id) {
+    if (over && active.id !== over.id) {
       setExperiences((items) => {
         const oldIndex = items.findIndex((item) => item.id === active.id);
         const newIndex = items.findIndex((item) => item.id === over.id);

--- a/src/SkillItem.css
+++ b/src/SkillItem.css
@@ -1,0 +1,152 @@
+.skill-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  margin: 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: default;
+}
+
+.skill-item:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.skill-item.dragging {
+  transform: rotate(3deg);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
+.skill-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 32px;
+  cursor: grab;
+  color: #6c757d;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.skill-drag-handle:hover {
+  background-color: #f8f9fa;
+  color: #495057;
+}
+
+.skill-drag-handle:active {
+  cursor: grabbing;
+}
+
+.drag-icon {
+  font-size: 18px;
+  line-height: 1;
+  user-select: none;
+}
+
+.skill-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.skill-header {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.skill-name {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  color: #212529;
+}
+
+.skill-proficiency {
+  font-size: 14px;
+  color: #6c757d;
+  background-color: #f8f9fa;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-weight: 500;
+  border: 1px solid #e9ecef;
+}
+
+.skill-logo {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid #e9ecef;
+  flex-shrink: 0;
+}
+
+.skill-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background-color: #ffffff;
+}
+
+.skill-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.delete-button {
+  background: none;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+  opacity: 0.6;
+}
+
+.delete-button:hover {
+  background-color: #f8f9fa;
+  opacity: 1;
+}
+
+.delete-button:active {
+  background-color: #e9ecef;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .skill-item {
+    padding: 10px 12px;
+    gap: 8px;
+  }
+  
+  .skill-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+  
+  .skill-name {
+    font-size: 14px;
+  }
+  
+  .skill-proficiency {
+    font-size: 12px;
+  }
+  
+  .skill-logo {
+    width: 28px;
+    height: 28px;
+  }
+}

--- a/src/SkillItem.js
+++ b/src/SkillItem.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import "./SkillItem.css";
+
+const SkillItem = ({ skill, onDelete }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: skill.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const handleDelete = async () => {
+    if (window.confirm("Are you sure you want to delete this skill?")) {
+      try {
+        const response = await fetch(
+          `http://localhost:5000/resume/skill/${skill.id}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to delete skill");
+        }
+
+        onDelete(skill.id);
+      } catch (err) {
+        console.error("Error deleting skill:", err);
+        alert("Failed to delete skill. Please try again.");
+      }
+    }
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`skill-item ${isDragging ? "dragging" : ""}`}
+    >
+      <div className="skill-drag-handle" {...attributes} {...listeners}>
+        <span className="drag-icon">⋮⋮</span>
+      </div>
+      
+      <div className="skill-content">
+        <div className="skill-header">
+          <h3 className="skill-name">{skill.name}</h3>
+          {skill.proficiency && (
+            <span className="skill-proficiency">{skill.proficiency}</span>
+          )}
+        </div>
+        
+        {skill.logo && (
+          <div className="skill-logo">
+            <img src={skill.logo} alt={`${skill.name} logo`} />
+          </div>
+        )}
+      </div>
+      
+      <div className="skill-actions">
+        <button
+          className="delete-button"
+          onClick={handleDelete}
+          title="Delete skill"
+        >
+          🗑️
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SkillItem;

--- a/src/SkillsList.css
+++ b/src/SkillsList.css
@@ -1,0 +1,52 @@
+.skills-list {
+  margin: 20px 0;
+  min-height: 50px;
+}
+
+.skills-loading,
+.skills-error,
+.skills-empty {
+  padding: 20px;
+  text-align: center;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  color: #6c757d;
+  margin: 10px 0;
+}
+
+.skills-error {
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+  color: #721c24;
+}
+
+.skills-error button {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.skills-error button:hover {
+  background-color: #c82333;
+}
+
+.skills-empty {
+  background-color: #d1ecf1;
+  border-color: #bee5eb;
+  color: #0c5460;
+}
+
+/* Drag and drop feedback */
+.skills-list .dnd-sortable-ghost {
+  opacity: 0.4;
+}
+
+.skills-list .dnd-sortable-chosen {
+  cursor: grabbing;
+}

--- a/src/SkillsList.js
+++ b/src/SkillsList.js
@@ -88,7 +88,7 @@ const SkillsList = () => {
   const handleDragEnd = (event) => {
     const { active, over } = event;
 
-    if (active.id !== over?.id) {
+    if (over && active.id !== over.id) {
       setSkills((items) => {
         const oldIndex = items.findIndex((item) => item.id === active.id);
         const newIndex = items.findIndex((item) => item.id === over.id);

--- a/src/SkillsList.js
+++ b/src/SkillsList.js
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import {
+  restrictToVerticalAxis,
+  restrictToParentElement,
+} from "@dnd-kit/modifiers";
+import SkillItem from "./SkillItem";
+import "./SkillsList.css";
+
+const SkillsList = () => {
+  const [skills, setSkills] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // Fetch skills from the server
+  useEffect(() => {
+    fetchSkills();
+  }, []);
+
+  const fetchSkills = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch("http://localhost:5000/resume/skill");
+      if (!response.ok) {
+        throw new Error("Failed to fetch skills");
+      }
+      const data = await response.json();
+      setSkills(data);
+    } catch (err) {
+      setError(err.message);
+      console.error("Error fetching skills:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Update the order on the server
+  const updateSkillOrder = async (newOrder) => {
+    try {
+      const response = await fetch(
+        "http://localhost:5000/resume/skill/reorder",
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            skills: newOrder.map((skill, index) => ({
+              id: skill.id,
+              order: index,
+            })),
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update skill order");
+      }
+
+      console.log("Skill order updated successfully");
+    } catch (err) {
+      console.error("Error updating skill order:", err);
+      // Optionally show an error message to the user
+      setError("Failed to update order. Please try again.");
+    }
+  };
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id) {
+      setSkills((items) => {
+        const oldIndex = items.findIndex((item) => item.id === active.id);
+        const newIndex = items.findIndex((item) => item.id === over.id);
+
+        const newOrder = arrayMove(items, oldIndex, newIndex);
+        
+        // Update the server with the new order
+        updateSkillOrder(newOrder);
+        
+        return newOrder;
+      });
+    }
+  };
+
+  const handleDelete = (id) => {
+    setSkills((prev) => prev.filter((skill) => skill.id !== id));
+  };
+
+  if (loading) {
+    return <div className="skills-loading">Loading skills...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="skills-error">
+        <p>Error: {error}</p>
+        <button onClick={fetchSkills}>Retry</button>
+      </div>
+    );
+  }
+
+  if (skills.length === 0) {
+    return (
+      <div className="skills-empty">
+        <p>No skills added yet. Add your first skill above!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="skills-list">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      >
+        <SortableContext
+          items={skills.map((skill) => skill.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {skills.map((skill) => (
+            <SkillItem
+              key={skill.id}
+              skill={skill}
+              onDelete={handleDelete}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+};
+
+export default SkillsList;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,37 @@
   resolved "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz"
   integrity sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
@@ -7866,7 +7897,7 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-"react-dom@^18.0.0 || ^19.0.0", react-dom@^18.2.0, react-dom@>=16.8:
+"react-dom@^18.0.0 || ^19.0.0", react-dom@^18.2.0, react-dom@>=16.8, react-dom@>=16.8.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -7978,7 +8009,7 @@ react-scripts@^5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-"react@^18.0.0 || ^19.0.0", react@^18.2.0, "react@>= 16", "react@>= 16.8 || 18.0.0", react@>=16.8:
+"react@^18.0.0 || ^19.0.0", react@^18.2.0, "react@>= 16", "react@>= 16.8 || 18.0.0", react@>=16.8, react@>=16.8.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -9229,7 +9260,7 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.7.0:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.7.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,6 +1221,14 @@
     "@dnd-kit/utilities" "^3.2.2"
     tslib "^2.0.0"
 
+"@dnd-kit/modifiers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz"
+  integrity sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
 "@dnd-kit/sortable@^10.0.0":
   version "10.0.0"
   resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz"


### PR DESCRIPTION
Implement drag-and-drop reordering for Experience and Skill items to enhance resume customization.

This PR integrates `@dnd-kit` for frontend drag-and-drop functionality, including fetching existing items, updating their order via API calls, and handling deletions. It also includes `API_COORDINATION.md` to guide the backend team on required endpoints (MLH-Fellowship/orientation-project-python#11).